### PR TITLE
Add release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 8
+      - name: Set release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+      - name: Package project
+        run: |
+          ./package.sh
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: nanoleaf-adapter-${{ env.RELEASE_VERSION }}.tgz
+          asset_name: nanoleaf-adapter-${{ env.RELEASE_VERSION }}.tgz
+          asset_content_type: application/gnutar
+      - name: Upload Release Asset Checksum
+        id: upload-release-asset-checksum
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: nanoleaf-adapter-${{ env.RELEASE_VERSION }}.tgz.sha256sum
+          asset_name: nanoleaf-adapter-${{ env.RELEASE_VERSION }}.tgz.sha256sum
+          asset_content_type: text/plain


### PR DESCRIPTION
This will automatically run the `package.sh` script and attach it to your release when you push a new tag named `vX.Y.Z`.